### PR TITLE
remove self type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         - uses: prefix-dev/setup-pixi@v0.5.1
           with:
             pixi-version: "latest"
-            environments: test, lint
+            environments: test
 
         - name: run tests
           run: |

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,5 +1,4 @@
 # name: Run updater that will check for conda-forge packages
-
 on:
   push:
     branches: [ "main" ]
@@ -15,8 +14,8 @@ jobs:
         - uses: prefix-dev/setup-pixi@v0.5.1
           with:
             pixi-version: "latest"
-            environments: test, lint
+            environments: lint
 
-        - name: run tests
+        - name: type check
           run: |
-           pixi run -e test pytest
+            pixi run type-check

--- a/pixi.lock
+++ b/pixi.lock
@@ -6437,7 +6437,7 @@ packages:
   name: rattler-build-conda-compat
   version: 0.1.2
   path: .
-  sha256: 775cd60c25c0cc04f323d71c07f4c1cea8f79d5ef0b015110d4ed2e562fc4a11
+  sha256: 26244d7fe823cdb32a6a8b63a5023e473a736a32805833183be07cd2c8c513a8
   requires_python: '>=3.8'
   editable: true
 - kind: conda

--- a/pixi.lock
+++ b/pixi.lock
@@ -117,8 +117,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py312h98912ed_0.conda
@@ -237,8 +237,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py312h41838bb_0.conda
@@ -357,8 +357,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py312he37b823_0.conda
@@ -462,8 +462,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
@@ -504,12 +504,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.10.1-py312h9a8786e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-hooks-4.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py312h9a8786e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.4-h194c7f8_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
@@ -521,6 +524,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240311-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.23.2-h9678756_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h8572e83_4.conda
@@ -540,12 +545,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.10.1-py312hbd25219_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-hooks-4.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.4-h37a9e06_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
@@ -557,6 +565,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240311-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/typos-1.23.2-h686f776_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py312h49ebfd2_4.conda
@@ -576,12 +586,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.10.1-py312h7e5086c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-hooks-4.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py312h7e5086c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.4-h30c5eda_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
@@ -593,6 +606,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240311-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.23.2-h6e96688_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312h389731b_4.conda
@@ -617,11 +632,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.10.1-py312h4389bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-hooks-4.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.4-h889d299_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
@@ -632,6 +650,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-70.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240311-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.23.2-h813c833_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
@@ -764,8 +784,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py312h98912ed_0.conda
@@ -889,8 +909,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py312h41838bb_0.conda
@@ -1014,8 +1034,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py312he37b823_0.conda
@@ -1124,8 +1144,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/truststore-0.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
@@ -4991,6 +5011,100 @@ packages:
   size: 3227
   timestamp: 1608166968312
 - kind: conda
+  name: mypy
+  version: 1.10.1
+  build: py312h4389bb4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.10.1-py312h4389bb4_0.conda
+  sha256: 00e7a8f7ac90709b9195eb5655a55f53b8a0297a563201d75b9406936ed69b0b
+  md5: 94e70ace716472016f5a717d4ab7531f
+  depends:
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 8414692
+  timestamp: 1719301939732
+- kind: conda
+  name: mypy
+  version: 1.10.1
+  build: py312h7e5086c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.10.1-py312h7e5086c_0.conda
+  sha256: d07f260bde42e963558bedbb5d8607c18a16f71a0dff45fb7cecc85bfcd97c6f
+  md5: 0aea347a79c70d8134ebd2efc897dda0
+  depends:
+  - __osx >=11.0
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 9622339
+  timestamp: 1719301964191
+- kind: conda
+  name: mypy
+  version: 1.10.1
+  build: py312h9a8786e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.10.1-py312h9a8786e_0.conda
+  sha256: d65af401f7368680f164990f110d084ee5139cd01a62189c76a88ab87ea50285
+  md5: 35504aad41d76808fa379bee8cd6882e
+  depends:
+  - libgcc-ng >=12
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 16471696
+  timestamp: 1719302037228
+- kind: conda
+  name: mypy
+  version: 1.10.1
+  build: py312hbd25219_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.10.1-py312hbd25219_0.conda
+  sha256: 353e75ea35e3c44294787f318e710379f7f0618962a918af90e91597a2710dea
+  md5: 38d751fa3fd6e793f11903f816ee1cfe
+  depends:
+  - __osx >=10.13
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 10370551
+  timestamp: 1719302314714
+- kind: conda
+  name: mypy_extensions
+  version: 1.0.0
+  build: pyha770c72_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+  sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+  md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 10492
+  timestamp: 1675543414256
+- kind: conda
   name: ncurses
   version: 6.4.20240210
   build: h078ce10_0
@@ -5517,6 +5631,73 @@ packages:
   - pkg:pypi/psutil
   size: 503677
   timestamp: 1705722843679
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312h4389bb4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py312h4389bb4_0.conda
+  sha256: c9ed9457fa4c4900b7f2fc5e28493bdd3885acb823ed48c01dae59f043a65ad8
+  md5: 86fd428b42be7495c93d0ff837adfc9e
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 509298
+  timestamp: 1719275243368
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312h7e5086c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py312h7e5086c_0.conda
+  sha256: d677457b2ce2e6ef6c2845c653e5bc39be9a59a900d95a5a7771b490f754cb5f
+  md5: e45a140733a4805d80e282c1ede40d0b
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 501703
+  timestamp: 1719274787455
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312h9a8786e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py312h9a8786e_0.conda
+  sha256: d629363515df957507411fd24db2a0635ac893e5d60b2ee2f656b53be9c70b1d
+  md5: 1aeffa86c55972ca4e88ac843eccedf2
+  depends:
+  - libgcc-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 493452
+  timestamp: 1719274737481
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312hbd25219_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py312hbd25219_0.conda
+  sha256: 06e949079497cf8e1c9e253b77be709ec0c11816656814e1ad857ac5cbbea65b
+  md5: db086d71e9be086313110a670b6d549f
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499307
+  timestamp: 1719274858092
 - kind: conda
   name: py-lief
   version: 0.14.1
@@ -6437,8 +6618,10 @@ packages:
   name: rattler-build-conda-compat
   version: 0.1.2
   path: .
-  sha256: 26244d7fe823cdb32a6a8b63a5023e473a736a32805833183be07cd2c8c513a8
-  requires_python: '>=3.8'
+  sha256: 929085ee146b252230362c01316df05aae13720321830046cf3f5415a18e8651
+  requires_dist:
+  - typing-extensions>=4.12.2
+  requires_python: '>=3.10'
   editable: true
 - kind: conda
   name: readline
@@ -7345,38 +7528,50 @@ packages:
   size: 20667
   timestamp: 1694154740564
 - kind: conda
+  name: types-pyyaml
+  version: 6.0.12.20240311
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20240311-pyhd8ed1ab_0.conda
+  sha256: 0101df6ec0d1bf632f215795225eb7d0308ae542c61a2f3a3ce66c39dad956fb
+  md5: df5d4b66033ecb54c7a4040627215529
+  depends:
+  - python >=3.6
+  license: Apache-2.0 AND MIT
+  size: 25219
+  timestamp: 1710134479192
+- kind: conda
   name: typing-extensions
-  version: 4.11.0
+  version: 4.12.2
   build: hd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-  sha256: aecbd9c601ba5a6c128da8975276fd817b968a9edc969b7ae97aee76e80a14a6
-  md5: 471e3988f8ca5e9eb3ce6be7eac3bcee
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+  md5: 52d648bd608f5737b123f510bb5514b5
   depends:
-  - typing_extensions 4.11.0 pyha770c72_0
+  - typing_extensions 4.12.2 pyha770c72_0
   license: PSF-2.0
   license_family: PSF
   purls: []
-  size: 10093
-  timestamp: 1712330094282
+  size: 10097
+  timestamp: 1717802659025
 - kind: conda
   name: typing_extensions
-  version: 4.11.0
+  version: 4.12.2
   build: pyha770c72_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
-  sha256: a7e8714d14f854058e971a6ed44f18cc37cc685f98ddefb2e6b7899a0cc4d1a2
-  md5: 6ef2fc37559256cf682d8b3375e89b80
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+  sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+  md5: ebe6952715e1d5eb567eeebf25250fa7
   depends:
   - python >=3.8
   license: PSF-2.0
   license_family: PSF
-  purls:
-  - pkg:pypi/typing-extensions
-  size: 37583
-  timestamp: 1712330089194
+  size: 39888
+  timestamp: 1717802653893
 - kind: conda
   name: typos
   version: 1.23.2

--- a/pixi.lock
+++ b/pixi.lock
@@ -6618,9 +6618,9 @@ packages:
   name: rattler-build-conda-compat
   version: 0.1.2
   path: .
-  sha256: 929085ee146b252230362c01316df05aae13720321830046cf3f5415a18e8651
+  sha256: 77dfbe3091b4797586a11b506f5c012c63cefd0e133cdf455477858eb1beaf97
   requires_dist:
-  - typing-extensions>=4.12.2
+  - typing-extensions>=4.12,<5
   requires_python: '>=3.10'
   editable: true
 - kind: conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,7 +40,7 @@ pre-commit = ">=3.7.1,<4"
 pre-commit-hooks = ">=4.6.0,<5"
 ruff = ">=0.4.8,<0.5"
 typos = ">=1.23.1,<2"
-mypy = ">=1.10.1,<1.11"
+mypy = ">=1.10.1,<2"
 types-pyyaml = ">=6.0.12.20240311,<6.0.13"
 
 [feature.lint.tasks]

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,7 +11,7 @@ platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 build_sdist = "pixi run python -m build --sdist"
 
 [dependencies]
-python = ">=3.8"
+python = ">=3.10"
 build = "*"
 rattler-build = "*"
 conda-build = "*"
@@ -19,6 +19,7 @@ conda-build = "*"
 conda = ">=4.2"
 pygithub = ">=2,<3"
 tomli = "*"
+typing-extensions = ">=4.12.2,<4.13"
 
 [pypi-dependencies]
 rattler-build-conda-compat = { path = ".", editable = true}
@@ -39,12 +40,16 @@ pre-commit = ">=3.7.1,<4"
 pre-commit-hooks = ">=4.6.0,<5"
 ruff = ">=0.4.8,<0.5"
 typos = ">=1.23.1,<2"
+mypy = ">=1.10.1,<1.11"
+types-pyyaml = ">=6.0.12.20240311,<6.0.13"
 
 [feature.lint.tasks]
 pre-commit-install = "pre-commit-install"
 pre-commit-run = "pre-commit run"
+type-check = "mypy"
 
 
 [environments]
 test = ["test"]
 lint = { features = ["lint"], no-default-feature = true, solve-group = "default" }
+

--- a/pixi.toml
+++ b/pixi.toml
@@ -52,4 +52,3 @@ type-check = "mypy src"
 [environments]
 test = ["test"]
 lint = { features = ["lint"], no-default-feature = true, solve-group = "default" }
-

--- a/pixi.toml
+++ b/pixi.toml
@@ -46,7 +46,7 @@ types-pyyaml = ">=6.0.12.20240311,<6.0.13"
 [feature.lint.tasks]
 pre-commit-install = "pre-commit-install"
 pre-commit-run = "pre-commit run"
-type-check = "mypy"
+type-check = "mypy src"
 
 
 [environments]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ ignore = [
     "T201",   # https://docs.astral.sh/ruff/rules/print/
     "A003",   # https://docs.astral.sh/ruff/rules/builtin-attribute-shadowing/
     "PTH",    # We dont want to change the API to pathlib just yet
+    "ANN101"  # Deprecated
 ]
 exclude = [
     "src/rattler_build_conda_compat/lint.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [{ name = "Nichita Morcotilo", email = "nichita@prefix.dev" }]
 license = { file = "LICENSE.txt" }
 dependencies = [
-    "typing-extensions>=4.12.2"
+    "typing-extensions>=4.12,<5"
 ]
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,13 @@ version = "0.1.2"
 readme = "README.md"
 authors = [{ name = "Nichita Morcotilo", email = "nichita@prefix.dev" }]
 license = { file = "LICENSE.txt" }
-
-requires-python = ">=3.8"
+dependencies = [
+    "typing-extensions>=4.12.2"
+]
+requires-python = ">=3.10"
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 line-length = 100
 
 [tool.ruff.format]
@@ -44,3 +46,7 @@ exclude = [
 [tool.pyright]
 venvPath = ".pixi/envs"
 venv = "default"
+
+[tool.mypy]
+python_version = "3.10"
+allow_redefinition = true

--- a/src/rattler_build_conda_compat/conditional_list.py
+++ b/src/rattler_build_conda_compat/conditional_list.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Generator, Generic, List, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -11,11 +14,13 @@ class IfStatement(Generic[T]):
     then: T | list[T]
     else_: T | list[T] | None
 
-ConditionalList = Union[T, IfStatement[T], List[Union[T, IfStatement[T]]]]
+
+ConditionalList = Union[T, IfStatement[T], list[T | IfStatement[T]]]  # noqa: UP007
 
 
 def visit_conditional_list(  # noqa: C901
-    value: T | IfStatement[T] | list[T | IfStatement[T]], evaluator: Callable[[Any], bool] | None = None
+    value: T | IfStatement[T] | list[T | IfStatement[T]],
+    evaluator: Callable[[Any], bool] | None = None,
 ) -> Generator[T, None, None]:
     """
     A function that yields individual branches of a conditional list.

--- a/src/rattler_build_conda_compat/conditional_list.py
+++ b/src/rattler_build_conda_compat/conditional_list.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Generator, Generic, TypeVar, Union
+from typing import Any, Callable, Generator, Generic, List, TypeVar, Union, cast
 
 T = TypeVar("T")
+K = TypeVar("K")
 
 
 class IfStatement(Generic[T]):
@@ -10,12 +11,11 @@ class IfStatement(Generic[T]):
     then: T | list[T]
     else_: T | list[T] | None
 
-
-ConditionalList = Union[T, "IfStatement[T]", list[Union[T, "IfStatement[T]"]]]
+ConditionalList = Union[T, IfStatement[T], List[Union[T, IfStatement[T]]]]
 
 
 def visit_conditional_list(  # noqa: C901
-    value: ConditionalList[T], evaluator: Callable[[Any], bool] | None = None
+    value: T | IfStatement[T] | list[T | IfStatement[T]], evaluator: Callable[[Any], bool] | None = None
 ) -> Generator[T, None, None]:
     """
     A function that yields individual branches of a conditional list.
@@ -30,7 +30,7 @@ def visit_conditional_list(  # noqa: C901
     A generator that yields the individual branches.
     """
 
-    def yield_from_list(value: list[T] | T) -> Generator[T, None, None]:
+    def yield_from_list(value: list[K] | K) -> Generator[K, None, None]:
         if isinstance(value, list):
             yield from value
         else:
@@ -57,8 +57,8 @@ def visit_conditional_list(  # noqa: C901
                         yield from yield_from_list(otherwise)
             else:
                 # In this case its not an if statement
-                yield element
+                yield cast(T, element)
         # If the element is not a dictionary, just yield it
         else:
             # (tim) I get a pyright error here, but I don't know how to fix it
-            yield element
+            yield cast(T, element)

--- a/src/rattler_build_conda_compat/lint.py
+++ b/src/rattler_build_conda_compat/lint.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 import re
 
 from inspect import cleandoc

--- a/src/rattler_build_conda_compat/loader.py
+++ b/src/rattler_build_conda_compat/loader.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
 from rattler_build_conda_compat.conditional_list import visit_conditional_list
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from os import PathLike
 
 
 class RecipeLoader(yaml.BaseLoader):
+    _namespace: dict[str, Any]|None = None
+
     @classmethod
     @contextmanager
-    def with_namespace(cls: RecipeLoader, namespace: dict[str, Any] | None) -> Iterator[None]:
+    def with_namespace(cls: type[RecipeLoader], namespace: dict[str, Any] | None) -> Iterator[None]:
         try:
             cls._namespace = namespace
             yield
@@ -23,9 +26,9 @@ class RecipeLoader(yaml.BaseLoader):
 
     def construct_sequence(  # noqa: C901
         self,
-        node: yaml.Node,
+        node: yaml.ScalarNode|yaml.SequenceNode|yaml.MappingNode,
         deep: bool = False,  # noqa: FBT002, FBT001
-    ) -> list[yaml.Node]:
+    ) -> list[yaml.ScalarNode]:
         """deep is True when creating an object/mapping recursively,
         in that case want the underlying elements available during construction
         """

--- a/src/rattler_build_conda_compat/loader.py
+++ b/src/rattler_build_conda_compat/loader.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 class RecipeLoader(yaml.BaseLoader):
-    _namespace: dict[str, Any]|None = None
+    _namespace: dict[str, Any] | None = None
 
     @classmethod
     @contextmanager
@@ -26,7 +26,7 @@ class RecipeLoader(yaml.BaseLoader):
 
     def construct_sequence(  # noqa: C901
         self,
-        node: yaml.ScalarNode|yaml.SequenceNode|yaml.MappingNode,
+        node: yaml.ScalarNode | yaml.SequenceNode | yaml.MappingNode,
         deep: bool = False,  # noqa: FBT002, FBT001
     ) -> list[yaml.ScalarNode]:
         """deep is True when creating an object/mapping recursively,

--- a/src/rattler_build_conda_compat/loader.py
+++ b/src/rattler_build_conda_compat/loader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Iterator, Self
+from typing import TYPE_CHECKING, Any, Iterator
 
 import yaml
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class RecipeLoader(yaml.BaseLoader):
     @classmethod
     @contextmanager
-    def with_namespace(cls: Self, namespace: dict[str, Any] | None) -> Iterator[None]:
+    def with_namespace(cls: RecipeLoader, namespace: dict[str, Any] | None) -> Iterator[None]:
         try:
             cls._namespace = namespace
             yield
@@ -22,7 +22,7 @@ class RecipeLoader(yaml.BaseLoader):
             del cls._namespace
 
     def construct_sequence(  # noqa: C901
-        self: Self,
+        self,
         node: yaml.Node,
         deep: bool = False,  # noqa: FBT002, FBT001
     ) -> list[yaml.Node]:

--- a/src/rattler_build_conda_compat/recipe_sources.py
+++ b/src/rattler_build_conda_compat/recipe_sources.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import typing
-from typing import Any, Iterator, Mapping, NotRequired, TypedDict
+from typing import Any, TypedDict
 
 from .conditional_list import ConditionalList, visit_conditional_list
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
 
 OptionalUrlList = str | list[str] | None
 
 
 class Source(TypedDict):
-    url: NotRequired[str]
+    url: str | None
 
 
 def get_all_url_sources(recipe: Mapping[Any, Any]) -> Iterator[str]:
@@ -29,10 +34,10 @@ def get_all_url_sources(recipe: Mapping[Any, Any]) -> Iterator[str]:
 
     # Try getting all url top-level sources
     if sources is not None:
-        sources = visit_conditional_list(sources, None)
-        for source in sources:
-            if "url" in source:
-                yield source["url"]
+        source_list = visit_conditional_list(sources, None)
+        for source in source_list:
+            if url:=source.get("url"):
+                yield url
 
     outputs = recipe.get("outputs", None)
     if outputs is None:
@@ -44,7 +49,7 @@ def get_all_url_sources(recipe: Mapping[Any, Any]) -> Iterator[str]:
         sources = typing.cast(ConditionalList[Source], sources)
         if sources is None:
             return
-        sources = visit_conditional_list(sources, None)
-        for source in sources:
-            if "url" in source:
-                yield source["url"]
+        source_list = visit_conditional_list(sources, None)
+        for source in source_list:
+            if url:=source.get("url"):
+                yield url

--- a/src/rattler_build_conda_compat/recipe_sources.py
+++ b/src/rattler_build_conda_compat/recipe_sources.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import sys
 import typing
 from typing import Any, TypedDict
 
 from .conditional_list import ConditionalList, visit_conditional_list
+
+if sys.version_info < (3, 11):
+    from typing_extensions import NotRequired
+else:
+    from typing import NotRequired
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -12,7 +18,7 @@ OptionalUrlList = str | list[str] | None
 
 
 class Source(TypedDict):
-    url: str | None
+    url: NotRequired[str]
 
 
 def get_all_url_sources(recipe: Mapping[Any, Any]) -> Iterator[str]:

--- a/src/rattler_build_conda_compat/recipe_sources.py
+++ b/src/rattler_build_conda_compat/recipe_sources.py
@@ -42,7 +42,7 @@ def get_all_url_sources(recipe: Mapping[Any, Any]) -> Iterator[str]:
     if sources is not None:
         source_list = visit_conditional_list(sources, None)
         for source in source_list:
-            if url:=source.get("url"):
+            if url := source.get("url"):
                 yield url
 
     outputs = recipe.get("outputs", None)
@@ -57,5 +57,5 @@ def get_all_url_sources(recipe: Mapping[Any, Any]) -> Iterator[str]:
             continue
         source_list = visit_conditional_list(sources, None)
         for source in source_list:
-            if url:=source.get("url"):
+            if url := source.get("url"):
                 yield url

--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 from collections import OrderedDict
 import json
 import os

--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -68,9 +68,10 @@ class MetaData(CondaMetaData):
         platform_and_arch = f"{self.config.platform}-{self.config.arch}"
 
         try:
-            with tempfile.NamedTemporaryFile(mode="w+") as outfile, tempfile.NamedTemporaryFile(
-                mode="w"
-            ) as variants_file:
+            with (
+                tempfile.NamedTemporaryFile(mode="w+") as outfile,
+                tempfile.NamedTemporaryFile(mode="w") as variants_file,
+            ):
                 # dump variants in our variants that will be used to generate recipe
                 if variants:
                     yaml.dump(variants, variants_file, default_flow_style=False)


### PR DESCRIPTION
Remove Self type because its not available for python 3.8.

Bumps to 3.10 and adds `typing-extensions`.

Fixes #19 