### PR TITLE
feat: change to 3.12 env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ exclude = [
 
 [tool.pyright]
 venvPath = ".pixi/envs"
-venv = "default"
+venv = "py312"
 
 [tool.mypy]
 python_version = "3.8"


### PR DESCRIPTION
Use `312` env by default because with zed you cannot select environments from the GUI which means I need something with pytest included.