### PR TITLE
feat: allow eval on non existing namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ mapping/*# pixi environments
 .pixi
 
 .vscode/
+
+.DS_Store

--- a/src/rattler_build_conda_compat/lint.py
+++ b/src/rattler_build_conda_compat/lint.py
@@ -55,7 +55,7 @@ def lint_recipe_yaml_by_schema(recipe_file):
         meta = yaml.load(fh)
 
     validator = Draft202012Validator(schema)
-
+    b"a".decode()
     lints = []
 
     for error in validator.iter_errors(meta):

--- a/src/rattler_build_conda_compat/lint.py
+++ b/src/rattler_build_conda_compat/lint.py
@@ -55,7 +55,6 @@ def lint_recipe_yaml_by_schema(recipe_file):
         meta = yaml.load(fh)
 
     validator = Draft202012Validator(schema)
-    b"a".decode()
     lints = []
 
     for error in validator.iter_errors(meta):

--- a/src/rattler_build_conda_compat/loader.py
+++ b/src/rattler_build_conda_compat/loader.py
@@ -17,6 +17,7 @@ SELECTOR_OPERATORS = ("and", "or", "not")
 
 class RecipeLoader(yaml.BaseLoader):
     _namespace: dict[str, Any] | None = None
+    _allow_missing_selector: bool = False
 
     @classmethod
     @contextmanager
@@ -72,7 +73,7 @@ class RecipeLoader(yaml.BaseLoader):
                                 if selector not in SELECTOR_OPERATORS
                             ]
                             for selector in split_selectors:
-                                if selector not in self._namespace:
+                                if self._namespace and selector not in self._namespace:
                                     cleaned_selector = selector.strip("(").rstrip(")")
                                     self._namespace[cleaned_selector] = True
 
@@ -115,7 +116,7 @@ def remove_empty_keys(variant_dict: dict[str, Any]) -> dict[str, Any]:
 
 
 def flatten_lists(variant_dict: dict[str, Any]) -> dict[str, Any]:
-    result_dict = {}
+    result_dict: dict[str, Any] = {}
     for key, value in variant_dict.items():
         if isinstance(value, dict):
             result_dict[key] = flatten_lists(value)

--- a/src/rattler_build_conda_compat/loader.py
+++ b/src/rattler_build_conda_compat/loader.py
@@ -111,7 +111,9 @@ def remove_empty_keys(variant_dict: dict[str, Any]) -> dict[str, Any]:
 def flatten_lists(variant_dict: dict[str, Any]) -> dict[str, Any]:
     result_dict = {}
     for key, value in variant_dict.items():
-        if isinstance(value, list) and value and isinstance(value[0], list):
+        if isinstance(value, dict):
+            result_dict[key] = flatten_lists(value)
+        elif isinstance(value, list) and value and isinstance(value[0], list):
             result_dict[key] = list(itertools.chain(*value))
         else:
             result_dict[key] = value
@@ -122,7 +124,9 @@ def flatten_lists(variant_dict: dict[str, Any]) -> dict[str, Any]:
 def parse_recipe_config_file(
     path: PathLike[str], namespace: dict[str, Any] | None, *, allow_missing_selector: bool = False
 ) -> dict[str, Any]:
-    with open(path) as f, RecipeLoader.with_namespace(namespace, allow_missing_selector):
+    with open(path) as f, RecipeLoader.with_namespace(
+        namespace, allow_missing_selector=allow_missing_selector
+    ):
         content = yaml.load(f, Loader=RecipeLoader)  # noqa: S506
     return flatten_lists(remove_empty_keys(content))
 

--- a/src/rattler_build_conda_compat/loader.py
+++ b/src/rattler_build_conda_compat/loader.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import itertools
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 import yaml
 
 from rattler_build_conda_compat.conditional_list import visit_conditional_list
+from rattler_build_conda_compat.utils import flatten_lists, remove_empty_keys
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -103,29 +103,6 @@ class RecipeLoader(yaml.BaseLoader):
 
 def load_yaml(content: str | bytes) -> Any:  # noqa: ANN401
     return yaml.load(content, Loader=yaml.BaseLoader)  # noqa: S506
-
-
-def remove_empty_keys(variant_dict: dict[str, Any]) -> dict[str, Any]:
-    filtered_dict = {}
-    for key, value in variant_dict.items():
-        if isinstance(value, list) and len(value) == 0:
-            continue
-        filtered_dict[key] = value
-
-    return filtered_dict
-
-
-def flatten_lists(variant_dict: dict[str, Any]) -> dict[str, Any]:
-    result_dict: dict[str, Any] = {}
-    for key, value in variant_dict.items():
-        if isinstance(value, dict):
-            result_dict[key] = flatten_lists(value)
-        elif isinstance(value, list) and value and isinstance(value[0], list):
-            result_dict[key] = list(itertools.chain(*value))
-        else:
-            result_dict[key] = value
-
-    return result_dict
 
 
 def parse_recipe_config_file(

--- a/src/rattler_build_conda_compat/utils.py
+++ b/src/rattler_build_conda_compat/utils.py
@@ -1,8 +1,9 @@
 import fnmatch
+import itertools
 from logging import getLogger
 import os
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Dict, Iterable
 
 
 VALID_METAS = ("recipe.yaml",)
@@ -171,3 +172,26 @@ def has_recipe(recipe_dir: Path) -> bool:
         return False
     except OSError:
         return False
+
+
+def remove_empty_keys(some_dict: Dict[str, Any]) -> Dict[str, Any]:
+    filtered_dict = {}
+    for key, value in some_dict.items():
+        if isinstance(value, list) and len(value) == 0:
+            continue
+        filtered_dict[key] = value
+
+    return filtered_dict
+
+
+def flatten_lists(some_dict: Dict[str, Any]) -> Dict[str, Any]:
+    result_dict: Dict[str, Any] = {}
+    for key, value in some_dict.items():
+        if isinstance(value, dict):
+            result_dict[key] = flatten_lists(value)
+        elif isinstance(value, list) and value and isinstance(value[0], list):
+            result_dict[key] = list(itertools.chain(*value))
+        else:
+            result_dict[key] = value
+
+    return result_dict

--- a/src/rattler_build_conda_compat/utils.py
+++ b/src/rattler_build_conda_compat/utils.py
@@ -1,9 +1,8 @@
 import fnmatch
-import itertools
 from logging import getLogger
 import os
 from pathlib import Path
-from typing import Any, Dict, Iterable
+from typing import Iterable
 
 
 VALID_METAS = ("recipe.yaml",)
@@ -172,26 +171,3 @@ def has_recipe(recipe_dir: Path) -> bool:
         return False
     except OSError:
         return False
-
-
-def remove_empty_keys(some_dict: Dict[str, Any]) -> Dict[str, Any]:
-    filtered_dict = {}
-    for key, value in some_dict.items():
-        if isinstance(value, list) and len(value) == 0:
-            continue
-        filtered_dict[key] = value
-
-    return filtered_dict
-
-
-def flatten_lists(some_dict: Dict[str, Any]) -> Dict[str, Any]:
-    result_dict: Dict[str, Any] = {}
-    for key, value in some_dict.items():
-        if isinstance(value, dict):
-            result_dict[key] = flatten_lists(value)
-        elif isinstance(value, list) and value and isinstance(value[0], list):
-            result_dict[key] = list(itertools.chain(*value))
-        else:
-            result_dict[key] = value
-
-    return result_dict

--- a/tests/__snapshots__/test_rattler_loader.ambr
+++ b/tests/__snapshots__/test_rattler_loader.ambr
@@ -1,4 +1,19 @@
 # serializer version: 1
+# name: test_load_recipe_with_missing_selectors
+  dict({
+    'package': dict({
+      'name': 'some-osx-recipe',
+      'version': '1.0.0',
+    }),
+    'requirements': dict({
+      'build': list([
+        'python',
+        'ruby',
+        'rust',
+      ]),
+    }),
+  })
+# ---
 # name: test_load_variants
   dict({
     'numpy': list([

--- a/tests/data/osx_recipe.yaml
+++ b/tests/data/osx_recipe.yaml
@@ -1,0 +1,16 @@
+package:
+    name: some-osx-recipe
+    version: 1.0.0
+requirements:
+    build:
+      - if: osx and arm64
+        then:
+          - python
+
+      - if: osx and aarch64
+        then:
+          - ruby
+
+      - if: unix
+        then:
+          - rust

--- a/tests/test_rattler_loader.py
+++ b/tests/test_rattler_loader.py
@@ -25,3 +25,15 @@ def test_load_all_requirements() -> None:
 
     content = load_all_requirements(recipe_content)
     print(content)
+
+
+def test_load_recipe_with_missing_selectors(snapshot) -> None:
+    osx_recipe = Path("tests/data/osx_recipe.yaml")
+
+    namespace = {"osx": True, "unix": True}
+
+    loaded_variants = parse_recipe_config_file(
+        str(osx_recipe), namespace, allow_missing_selector=True
+    )
+
+    assert loaded_variants == snapshot


### PR DESCRIPTION
This PR aims to add `allow_missing_selector` argument for `RecipeLoader` which will be used by conda-smithy linter to suggest some lints for osx platform. To do this, we need to ignore other selectors ( treat them as true ) so the osx one will be evaluated.
Also, I'm adding `flatten_lists` that will make just a list of values for this case:


```
python:
if: osx
  - 3.8
 
python:
if: unix
 - 3.9
```

`So instead of having python: [[3.8], [3.9]]` we will have python: `[3.8, 3.9]`

